### PR TITLE
Removes broken `Disconnect` button for Lattice and fixes typo.

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -309,7 +309,7 @@ export default function AccountDetails({
               <AccountGroupingRow>
                 {formatConnectorName()}
                 <div>
-                  {connector !== injected && connector !== walletlink && (
+                  {connector !== injected && connector !== walletlink && connector !== lattice && (
                     <WalletAction
                       style={{ fontSize: '.825rem', fontWeight: 400, marginRight: '8px' }}
                       onClick={() => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -107,7 +107,7 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     connector: lattice,
     name: 'Lattice',
     iconName: 'gridPlusWallet.png',
-    description: 'Connect to GridPluse Wallet.',
+    description: 'Connect to GridPlus Wallet.',
     href: null,
     color: '#40a9ff',
     mobile: true


### PR DESCRIPTION
The `Disconnect` action is not currently possible with the GridPlus subprovider.
I would need to add an accessor here: https://github.com/0xProject/tools/blob/development/subproviders/src/subproviders/lattice.ts
which would call `forgetDevice` on the internal instance of the lattice keyring,
which is unfortunately a private readonly variable in our subprovider.
After this, I would need to add a method to our `lattice-connector` in the web3-react
repo.
I think it's fine for now to just disable the button in the UI, since the Lattice
gets forgotten whenever the page refreshes anyway.