### PR TITLE
Updates Routing Logic

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,15 +18,19 @@ export const MKR = new Token(ChainId.MAINNET, '0x9f8F72aA9304c8B593d555F12eF6589
 export const AMPL = new Token(ChainId.MAINNET, '0xD46bA6D942050d489DBd938a2C909A5d5039A161', 9, 'AMPL', 'Ampleforth')
 export const WBTC = new Token(ChainId.MAINNET, '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', 18, 'WBTC', 'Wrapped BTC')
 export const SUSHI = new Token(ChainId.MAINNET, '0x6B3595068778DD592e39A122f4f5a5cF09C90fE2', 18, 'SUSHI', 'SushiToken')
-export const YAM = new Token(ChainId.MAINNET, '0x0e2298E3B3390e3b945a5456fBf59eCc3f55DA16', 18, 'YAM', 'YAM')
 export const RUNE = new Token(ChainId.MAINNET, '0x3155BA85D5F96b2d030a4966AF206230e46849cb', 18, 'RUNE', 'RUNE.ETH')
-export const YFI = new Token(ChainId.MAINNET, '0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e', 18, 'YFI', 'Yearn')
 export const CREAM = new Token(ChainId.MAINNET, '0x2ba592F78dB6436527729929AAf6c908497cB200', 18, 'CREAM', 'Cream')
 export const BAC = new Token(ChainId.MAINNET, '0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a', 18, 'BAC', 'Basis Cash')
 export const FXS = new Token(ChainId.MAINNET, '0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0', 18, 'FXS', 'Frax Share')
-export const CRV = new Token(ChainId.MAINNET, '0xD533a949740bb3306d119CC777fa900bA034cd52', 18, 'CRV', 'Curve Dao Token')
 export const ALPHA = new Token(ChainId.MAINNET, '0xa1faa113cbE53436Df28FF0aEe54275c13B40975', 18, 'ALPHA', 'AlphaToken')
 export const USDP = new Token(ChainId.MAINNET, '0x1456688345527bE1f37E9e627DA0837D6f08C925', 18, 'USDP', 'USDP Stablecoin')
+
+// tokens to set custom base pairs for
+export const DUCK = new Token(ChainId.MAINNET, '0x92E187a03B6CD19CB6AF293ba17F2745Fd2357D5', 18, 'DUCK', 'DUCK')
+export const BAB = new Token(ChainId.MAINNET, '0xC36824905dfF2eAAEE7EcC09fCC63abc0af5Abc5', 18, 'BAB', 'BAB')
+export const HBTC = new Token(ChainId.MAINNET, '0x0316EB71485b0Ab14103307bf65a021042c6d380', 18, 'HBTC', 'Huobi BTC')
+export const FRAX = new Token(ChainId.MAINNET, '0x853d955aCEf822Db058eb8505911ED77F175b99e', 18, 'FRAX', 'FRAX')
+export const ibETH = new Token(ChainId.MAINNET, '0xeEa3311250FE4c3268F8E684f7C87A82fF183Ec1', 8, 'ibETHv2', 'Interest Bearing Ether v2')
 
 const WETH_ONLY: ChainTokenList = {
   [ChainId.MAINNET]: [WETH[ChainId.MAINNET]],
@@ -39,7 +43,7 @@ const WETH_ONLY: ChainTokenList = {
 // used to construct intermediary pairs for trading
 export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, SUSHI, YAM, WBTC, RUNE, CREAM, BAC, FXS, CRV, ALPHA, USDP]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, WBTC, RUNE]
 }
 
 /**
@@ -48,20 +52,25 @@ export const BASES_TO_CHECK_TRADES_AGAINST: ChainTokenList = {
  */
 export const CUSTOM_BASES: { [chainId in ChainId]?: { [tokenAddress: string]: Token[] } } = {
   [ChainId.MAINNET]: {
-    [AMPL.address]: [DAI, WETH[ChainId.MAINNET]]
+    [AMPL.address]: [DAI, WETH[ChainId.MAINNET]],
+    [DUCK.address]: [USDP, WETH[ChainId.MAINNET]],
+    [BAB.address]: [BAC, WETH[ChainId.MAINNET]],
+    [HBTC.address]: [CREAM, WETH[ChainId.MAINNET]],
+    [FRAX.address]: [FXS, WETH[ChainId.MAINNET]],
+    [ibETH.address]: [ALPHA, WETH[ChainId.MAINNET]],
   }
 }
 
 // used for display in the default list when adding liquidity
 export const SUGGESTED_BASES: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, WBTC]
 }
 
 // used to construct the list of all pairs we consider by default in the frontend
 export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
   ...WETH_ONLY,
-  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT]
+  [ChainId.MAINNET]: [...WETH_ONLY[ChainId.MAINNET], DAI, USDC, USDT, WBTC]
 }
 
 export const PINNED_PAIRS: { readonly [chainId in ChainId]?: [Token, Token][] } = {

--- a/src/hooks/Trades.ts
+++ b/src/hooks/Trades.ts
@@ -1,5 +1,5 @@
-import { Currency, CurrencyAmount, Pair, Token, Trade } from '@uniswap/sdk'
-import flatMap from 'lodash.flatmap'
+import { Currency, CurrencyAmount, Pair, Token, Trade, ChainId } from '@uniswap/sdk'
+//import flatMap from 'lodash.flatmap'
 import { useMemo } from 'react'
 
 import { BASES_TO_CHECK_TRADES_AGAINST, CUSTOM_BASES } from '../constants'
@@ -8,56 +8,64 @@ import { wrappedCurrency } from '../utils/wrappedCurrency'
 
 import { useActiveWeb3React } from './index'
 
+
+function generateAllRoutePairs(tokenA?: Token, tokenB?: Token, chainId?: ChainId): [Token, Token][] {
+  const bases: Token[] = chainId ? BASES_TO_CHECK_TRADES_AGAINST[chainId] : []
+  const customBases = chainId !== undefined ? CUSTOM_BASES[chainId] : undefined
+  const customBasesA = customBases && tokenA ? customBases[tokenA.address] ?? [] : []
+  const customBasesB = customBases && tokenB ? customBases[tokenB.address] ?? [] : []
+
+  const allBases = [...new Set([...bases, ...customBasesA, ...customBasesB])]
+
+  const basePairs: [Token, Token][] = [];
+  for (let i = 0; i < allBases.length; i++) {
+    for (let j = i + 1; j < allBases.length; j++) {
+      basePairs.push([allBases[i], allBases[j]]);
+    }
+  }
+
+  return [
+    // the direct pair
+    [tokenA, tokenB],
+    // token A against all bases
+    ...allBases.map((base): [Token | undefined, Token] => [tokenA, base]),
+    // token B against all bases
+    ...allBases.map((base): [Token | undefined, Token] => [tokenB, base]),
+    // each base against all bases
+    ...basePairs
+  ]
+    .filter((tokens): tokens is [Token, Token] => Boolean(tokens[0] && tokens[1]))
+    .filter(([t0, t1]) => t0.address !== t1.address)
+    .filter(([tokenA, tokenB]) => {
+      if (!chainId) return true
+      const restrictedBases = CUSTOM_BASES[chainId]
+      if (!restrictedBases) return true
+
+      const restrictedBasesA: Token[] | undefined = restrictedBases[tokenA.address]
+      const restrictedBasesB: Token[] | undefined = restrictedBases[tokenB.address]
+
+      if (!restrictedBasesA && !restrictedBasesB) return true
+
+      if (restrictedBasesA && !restrictedBasesA.find(base => tokenB.equals(base))) return false
+      if (restrictedBasesB && !restrictedBasesB.find(base => tokenA.equals(base))) return false
+
+      return true
+    })
+}
+
+
 function useAllCommonPairs(currencyA?: Currency, currencyB?: Currency): Pair[] {
   const { chainId } = useActiveWeb3React()
-
-  const bases: Token[] = chainId ? BASES_TO_CHECK_TRADES_AGAINST[chainId] : []
 
   const [tokenA, tokenB] = chainId
     ? [wrappedCurrency(currencyA, chainId), wrappedCurrency(currencyB, chainId)]
     : [undefined, undefined]
 
-  const basePairs: [Token, Token][] = useMemo(
-    () =>
-      flatMap(bases, (base): [Token, Token][] => bases.map(otherBase => [base, otherBase])).filter(
-        ([t0, t1]) => t0.address !== t1.address
-      ),
-    [bases]
-  )
-
-  const allPairCombinations: [Token, Token][] = useMemo(
-    () =>
-      tokenA && tokenB
-        ? [
-            // the direct pair
-            [tokenA, tokenB],
-            // token A against all bases
-            ...bases.map((base): [Token, Token] => [tokenA, base]),
-            // token B against all bases
-            ...bases.map((base): [Token, Token] => [tokenB, base]),
-            // each base against all bases
-            ...basePairs
-          ]
-            .filter((tokens): tokens is [Token, Token] => Boolean(tokens[0] && tokens[1]))
-            .filter(([t0, t1]) => t0.address !== t1.address)
-            .filter(([tokenA, tokenB]) => {
-              if (!chainId) return true
-              const customBases = CUSTOM_BASES[chainId]
-              if (!customBases) return true
-
-              const customBasesA: Token[] | undefined = customBases[tokenA.address]
-              const customBasesB: Token[] | undefined = customBases[tokenB.address]
-
-              if (!customBasesA && !customBasesB) return true
-
-              if (customBasesA && !customBasesA.find(base => tokenB.equals(base))) return false
-              if (customBasesB && !customBasesB.find(base => tokenA.equals(base))) return false
-
-              return true
-            })
-        : [],
-    [tokenA, tokenB, bases, basePairs, chainId]
-  )
+  const allPairCombinations: [Token, Token][] = useMemo(() => generateAllRoutePairs(tokenA, tokenB, chainId), [
+    tokenA,
+    tokenB,
+    chainId
+  ])
 
   const allPairs = usePairs(allPairCombinations)
 
@@ -86,7 +94,7 @@ export function useTradeExactIn(currencyAmountIn?: CurrencyAmount, currencyOut?:
   return useMemo(() => {
     if (currencyAmountIn && currencyOut && allowedPairs.length > 0) {
       return (
-        Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, { maxHops: 2, maxNumResults: 1 })[0] ?? null
+        Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, { maxHops: 3, maxNumResults: 1 })[0] ?? null
       )
     }
     return null
@@ -102,7 +110,7 @@ export function useTradeExactOut(currencyIn?: Currency, currencyAmountOut?: Curr
   return useMemo(() => {
     if (currencyIn && currencyAmountOut && allowedPairs.length > 0) {
       return (
-        Trade.bestTradeExactOut(allowedPairs, currencyIn, currencyAmountOut, { maxHops: 2, maxNumResults: 1 })[0] ??
+        Trade.bestTradeExactOut(allowedPairs, currencyIn, currencyAmountOut, { maxHops: 3, maxNumResults: 1 })[0] ??
         null
       )
     }


### PR DESCRIPTION
Refactored the routing logic to make use of the `CUSTOM_BASES`. Instead of limiting a token to the custom bases set for it, it adds all of the custom bases to the possible pairs array in Trades.ts

This prevents weird routes from showing up by limiting the tokens that are in the `BASES_TO_CHECK_TRADES_AGAINST`.

Also made the max hops 3 again. Helps with for example going from `USDC -> ETH -> USDP -> DUCK`.
